### PR TITLE
When exporting all accounts to QIF from Quicken 2013 with transaction…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,12 @@ Here's a sample of a structure creation::
    '!Type:Cat\nNfood\nE\n^\n!Account\nNMy Cc\nTBank\n^\n!Type:Bank\nD02/11/2013\nT...
    ...
 
+If you find that your QIF files date format has the month before day (like 12/25/2019 for December 25, 2019), then set 
+
+   QifParser.MONTH_IS_BEFORE_DAY_IN_DATES = True
+
+before calling QifParser.parse().
+
 More infos
 ============
 For more informations about qif format:

--- a/qifparse/qif.py
+++ b/qifparse/qif.py
@@ -11,6 +11,9 @@ ACCOUNT_TYPES = [
     'Oth L',
     'Invoice',  # Quicken for business only
     'Invst',
+    'Port',
+    '401(k)/403(b)',
+    'Mutual',
 ]
 
 MEMORIZED_TRANSACTION_TYPES = [
@@ -33,7 +36,8 @@ class Qif(object):
     def add_account(self, item):
         if not isinstance(item, Account):
             raise RuntimeError(six.u("item not recognized"))
-        self._accounts.append(item)
+        if not [a for a in self._accounts if (a.name == item.name and a.account_type == item.account_type)]:
+            self._accounts.append(item)
 
     def add_category(self, item):
         if not isinstance(item, Category):
@@ -99,7 +103,7 @@ class Qif(object):
             return tuple(self._transactions.values())
         else:
             tr = []
-            tr.extend(self._transactions.values)
+            tr.extend(self._transactions.values())
             for acc in self._accounts:
                 tr.extend(acc.transactions)
 

--- a/qifparse/tests/multiAccount.qif
+++ b/qifparse/tests/multiAccount.qif
@@ -1,0 +1,58 @@
+!Option:AutoSwitch
+!Account
+NCity Checking
+TBank
+^
+NGlobal Credit Card
+TCCard
+L10,000
+^
+!Clear:AutoSwitch
+!Option:AutoSwitch
+!Account
+NCity Checking
+TBank
+^
+!Type:Bank
+D3/27' 3
+U0.00
+T0.00
+CX
+POpening Balance
+L[City Checking]
+^
+D1/ 2/92
+U123.45
+T123.45
+CX
+PDeposit
+LSalary
+^
+!Account
+NGlobal Credit Card
+TCCard
+L10,000
+^
+!Type:CCard
+D6/17'15
+U0.00
+T0.00
+CX
+POpening Balance
+L[Global Credit Card]
+^
+D6/18'15
+U-1,234.56
+T-1,234.56
+C*
+PLocal Store
+LFood
+^
+
+D6/19'15
+U1,234.56
+T1,234.56
+C*
+PLocal Store
+LFood
+^

--- a/qifparse/tests/test_parse.py
+++ b/qifparse/tests/test_parse.py
@@ -1,33 +1,89 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+from decimal import Decimal
 import unittest
 import os
 from qifparse.parser import QifParser
 
 filename = os.path.join(os.path.dirname(__file__), 'file.qif')
 filename2 = os.path.join(os.path.dirname(__file__), 'transactions_only.qif')
+filename_multi = os.path.join(os.path.dirname(__file__), 'multiAccount.qif')
 
 
 class TestQIFParsing(unittest.TestCase):
 
     def testParseFile(self):
-        qif = QifParser.parse(open(filename))
+        with open(filename) as f:
+            QifParser.MONTH_IS_BEFORE_DAY_IN_DATES = False
+            qif = QifParser.parse(f)
         self.assertTrue(qif)
 
     def testWriteFile(self):
-        data = open(filename).read()
-        qif = QifParser.parse(open(filename))
+        with open(filename) as f:
+            data = f.read()
+        with open(filename) as f:
+            QifParser.MONTH_IS_BEFORE_DAY_IN_DATES = False
+            qif = QifParser.parse(f)
 #        out = open('out.qif', 'w')
 #        out.write(str(qif))
 #        out.close()
-        self.assertEquals(data, str(qif))
+        self.assertEqual(data, str(qif))
 
     def testParseTransactionsFile(self):
-        data = open(filename2).read()
-        qif = QifParser.parse(open(filename2))
+        with open(filename2) as f:
+            data = f.read()
+        with open(filename2) as f:
+            QifParser.MONTH_IS_BEFORE_DAY_IN_DATES = False
+            qif = QifParser.parse(f)
 #        out = open('out.qif', 'w')
 #        out.write(str(qif))
 #        out.close()
-        self.assertEquals(data, str(qif))
+        self.assertEqual(data, str(qif))
+
+    def testParseMultiAccountFile(self):
+        with open(filename_multi) as f:
+            QifParser.MONTH_IS_BEFORE_DAY_IN_DATES = True
+            qif = QifParser.parse(f)
+
+        self.assertEqual(2, len(qif.get_accounts()))
+        self.assertEqual('City Checking', qif.get_accounts()[0].name)
+        self.assertEqual('Bank', qif.get_accounts()[0].account_type)
+        self.assertEqual('Global Credit Card', qif.get_accounts()[1].name)
+        self.assertEqual('CCard', qif.get_accounts()[1].account_type)
+
+        city_account_list = qif.get_accounts(name='City Checking')
+        self.assertEqual(1, len(city_account_list))
+        city_transactions = city_account_list[0].get_transactions()[0]
+        self.assertEqual(2, len(city_transactions))
+        self.assert_transaction(city_transactions[0], self.to_datetime('2003-03-27'), Decimal('0.00'),
+                'X', 'Opening Balance', to_account='City Checking')
+        self.assert_transaction(city_transactions[1], self.to_datetime('1992-01-02'), Decimal('123.45'),
+                'X', 'Deposit', category='Salary')
+
+        credit_card_account_list = qif.get_accounts(name='Global Credit Card')
+        self.assertEqual(1, len(credit_card_account_list))
+        credit_transactions = credit_card_account_list[0].get_transactions()[0]
+        self.assertEqual(3, len(credit_transactions))
+        self.assert_transaction(credit_transactions[0], self.to_datetime('2015-06-17'), Decimal('0.00'),
+                'X', 'Opening Balance', to_account='Global Credit Card')
+        self.assert_transaction(credit_transactions[1], self.to_datetime('2015-06-18'), Decimal('-1234.56'),
+                '*', 'Local Store', category='Food')
+        self.assert_transaction(credit_transactions[2], self.to_datetime('2015-06-19'), Decimal('1234.56'),
+                '*', 'Local Store', category='Food')
+
+
+    def assert_transaction(self, txn, when, amount, cleared, payee, category=None, to_account=None):
+        self.assertEqual(txn.date, when)
+        self.assertEqual(txn.amount, amount)
+        self.assertEqual(txn.cleared, cleared)
+        self.assertEqual(txn.payee, payee)
+        if category:
+            self.assertEqual(txn.category, category)
+        if to_account:
+            self.assertEqual(txn.to_account, to_account)
+
+    def to_datetime(self, date_str):
+        return datetime.strptime(date_str, '%Y-%m-%d')
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
…s only, additional fields and types are included.

In particular, Option:AutoSwitch is described here:
  https://community.quicken.com/discussion/7147335/explain-the-qif-format-for-autoswitch

A new test is added to ensure correct handling.

Additionally:
* Quicken 2013 can include trailing spaces in account types, so that is now allowed in parsing.
* Remove commas in input amounts during parsing into Decimal objects.
* Support different input formats of dates using the static variable: QifParser.MONTH_IS_BEFORE_DAY_IN_DATES
* Properly close files in unit tests to avoid warnings in python3.8+